### PR TITLE
Add patch to update kubevirt v1.5.0 dependencies

### DIFF
--- a/kubevirt-patch/0001-Bump-dependency-versions-for-kubevirt-v1.5.0.patch
+++ b/kubevirt-patch/0001-Bump-dependency-versions-for-kubevirt-v1.5.0.patch
@@ -1,0 +1,75 @@
+From 610083ca7acf52ab05640460d8a778bcdbe1b97b Mon Sep 17 00:00:00 2001
+From: Intel <intel.com>
+Date: Wed, 18 Jun 2025 04:00:38 +0000
+Subject: [PATCH] Bump dependency versions for kubevirt v1.5.0
+
+Two changes:
+- make bump-images
+- Update go_version in WORKSPACE from 1.23.4 -> 1.23.10
+
+This patch was created and verified on Kubevirt release v1.5.0
+---
+ WORKSPACE        | 8 ++++----
+ hack/rpm-deps.sh | 6 +++---
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index cf3cdbd89e..5003587cdc 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -171,7 +171,7 @@ load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies", "rpm")
+ go_rules_dependencies()
+ 
+ go_register_toolchains(
+-    go_version = "1.23.4",
++    go_version = "1.23.10",
+     nogo = "@//:nogo_vet",
+ )
+ 
+@@ -306,21 +306,21 @@ container_deps()
+ # Pull go_image_base
+ container_pull(
+     name = "go_image_base",
+-    digest = "sha256:a7af3ef5d69f6534ba0492cc7d6b8fbcffddcb02511b45becc2fac752f907584",
++    digest = "sha256:0d0479220a36ba3e9665b5c08b635ed5421bec501ed38365e48eb716986b20eb",
+     registry = "gcr.io",
+     repository = "distroless/base-debian12",
+ )
+ 
+ container_pull(
+     name = "go_image_base_aarch64",
+-    digest = "sha256:198302a46cd40ab2e24ee54d39ba0919a431e59289fd7b87f798b62e2076c62a",
++    digest = "sha256:5515eef798481300d4f7c16b0e7e72fa8b8221954cf8b6adb9d76bbfa66dec32",
+     registry = "gcr.io",
+     repository = "distroless/base-debian12",
+ )
+ 
+ container_pull(
+     name = "go_image_base_s390x",
+-    digest = "sha256:642791d0afe3d071e365923e65203074f30bad4ca621309d2eab52bf2d32077e",
++    digest = "sha256:e7ea68353aa46a09eb3f5b11587f62548f175e23378e329cba3450f80ce5e34f",
+     registry = "gcr.io",
+     repository = "distroless/base-debian12",
+ )
+diff --git a/hack/rpm-deps.sh b/hack/rpm-deps.sh
+index c3da8cfda5..f6d54ae7ab 100755
+--- a/hack/rpm-deps.sh
++++ b/hack/rpm-deps.sh
+@@ -6,11 +6,11 @@ source hack/common.sh
+ source hack/bootstrap.sh
+ source hack/config.sh
+ 
+-LIBVIRT_VERSION=${LIBVIRT_VERSION:-0:10.10.0-4.el9}
+-QEMU_VERSION=${QEMU_VERSION:-17:9.1.0-12.el9}
++LIBVIRT_VERSION=${LIBVIRT_VERSION:-0:10.10.0-12.el9}
++QEMU_VERSION=${QEMU_VERSION:-17:9.1.0-19.el9}
+ SEABIOS_VERSION=${SEABIOS_VERSION:-0:1.16.3-4.el9}
+ EDK2_VERSION=${EDK2_VERSION:-0:20241117-2.el9}
+-LIBGUESTFS_VERSION=${LIBGUESTFS_VERSION:-1:1.54.0-3.el9}
++LIBGUESTFS_VERSION=${LIBGUESTFS_VERSION:-1:1.54.0-7.el9}
+ GUESTFSTOOLS_VERSION=${GUESTFSTOOLS_VERSION:-0:1.52.2-2.el9}
+ PASST_VERSION=${PASST_VERSION:-0:0^20250121.g4f2c8e7-3.el9}
+ VIRTIOFSD_VERSION=${VIRTIOFSD_VERSION:-0:1.13.0-1.el9}
+-- 
+2.43.0
+

--- a/kubevirt-patch/0001-Patching-Kubevirt-with-GTK-libraries_v1.patch
+++ b/kubevirt-patch/0001-Patching-Kubevirt-with-GTK-libraries_v1.patch
@@ -1,4 +1,4 @@
-From 7613b128c484909ae91cdd10fcdcc2d9f18c5dda Mon Sep 17 00:00:00 2001
+From 527d3eced3be7f24873ae08109ebd3de283cdcd8 Mon Sep 17 00:00:00 2001
 From: Intel <intel.com>
 Date: Thu, 29 May 2025 17:52:41 +0530
 Subject: [PATCH] Patching Kubevirt with GTK libraries
@@ -11,10 +11,10 @@ and update the SHA256SUM in WORKSPACE file before continue building Kubevirt
 
 This patch was created and verified on Kubevirt release v1.5.0
 ---
- WORKSPACE                     |  9 ++++++
- cmd/virt-launcher/BUILD.bazel | 10 ++++++
- hack/rpm-deps.sh              | 60 +++++++++++++++++++++++++++++++++++
- 3 files changed, 79 insertions(+)
+ WORKSPACE                     |  9 ++++++++
+ cmd/virt-launcher/BUILD.bazel | 10 +++++++++
+ hack/rpm-deps.sh              | 42 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 61 insertions(+)
 
 diff --git a/WORKSPACE b/WORKSPACE
 index cf3cdbd89e..b3aa44ded3 100644
@@ -65,10 +65,10 @@ index 0ebe807739..4505b61504 100644
          ],
      }),
 diff --git a/hack/rpm-deps.sh b/hack/rpm-deps.sh
-index c3da8cfda5..51b6127c5c 100755
+index c3da8cfda5..95bb55f5bd 100755
 --- a/hack/rpm-deps.sh
 +++ b/hack/rpm-deps.sh
-@@ -48,6 +48,65 @@ centos_extra="
+@@ -48,6 +48,47 @@ centos_extra="
    glibc-minimal-langpack
    libcurl-minimal
  "
@@ -116,7 +116,7 @@ index c3da8cfda5..51b6127c5c 100755
  
  # create a rpmtree for our test image with misc. tools.
  testimage_main="
-@@ -219,6 +278,7 @@ if [ -z "${SINGLE_ARCH}" ] || [ "${SINGLE_ARCH}" == "x86_64" ]; then
+@@ -219,6 +260,7 @@ if [ -z "${SINGLE_ARCH}" ] || [ "${SINGLE_ARCH}" == "x86_64" ]; then
          ${bazeldnf_repos} \
          $centos_main \
          $centos_extra \
@@ -125,5 +125,5 @@ index c3da8cfda5..51b6127c5c 100755
          $launcherbase_x86_64 \
          $launcherbase_extra
 -- 
-2.34.1
+2.43.0
 

--- a/kubevirt-patch/README.md
+++ b/kubevirt-patch/README.md
@@ -196,6 +196,13 @@ The original idea to build within the Centos container comes from this [link](ht
     git checkout v1.5.0
     ```
 
+1. Apply a patch to kubevirt to update dependencies which resolve potential security issues since the original v1.5.0 kubevirt was released
+    ```sh
+    git apply your/path/to/kubevirt-patch/0001-Bump-dependency-versions-for-kubevirt-v1.5.0.patch
+    ```
+
+1. [OPTIONAL] Update kubevirt dependency images using the `make bump-images` command. Note that you may also have to update `go_version` in `WORKSPACE` if applicable.
+
 1. Apply the kubevirt patch from this repo to expand kubevirt virt-launcher image with additional dependencies to support GTK
     ```sh
     git apply your/path/to/applications.virtualization.maverickflats-tiberos-itep/docs/0001-Patching-Kubevirt-with-GTK-libraries_v1.patch


### PR DESCRIPTION
Note: I also regenerated the existing patch (which is why it has superficial edits). I did this because it was giving me a "malformed patch" error while trying to apply it - I think at some point it accidentally got edited. This version definitely applies correctly to v1.5.0, and has the same content as before. 