### PR TITLE
Device plugin base image from alpine to debian:stable-slim

### DIFF
--- a/device-plugins-for-kubernetes/Dockerfile
+++ b/device-plugins-for-kubernetes/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a minimal base image
-FROM alpine:latest
+FROM debian:stable-slim
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
- As per OSPDT if we are distributing alpine, there is lot of work for inluding licenses/legal as all is trimmed off.
- Recommendation is to use debian base image.