### PR TITLE
Add vendor/device id placeholders to kubevirt-cr-gfx-sriov.yaml for later substitution

### DIFF
--- a/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
+++ b/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
@@ -33,6 +33,6 @@ spec:
       - pciVendorSelector: "8086:a780"
         resourceName: "intel.com/sriov-gpudevice"
         externalResourceProvider: false
-      - pciVendorSelector: "$INTEL_IDV_GPU_VENDOR_ID:$INTEL_IDV_GPU_PRODUCT_ID"
+      - pciVendorSelector: "${INTEL_IDV_GPU_VENDOR_ID}:${INTEL_IDV_GPU_PRODUCT_ID}"
         resourceName: "intel.com/sriov-gpudevice"
         externalResourceProvider: false

--- a/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
+++ b/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
@@ -33,3 +33,6 @@ spec:
       - pciVendorSelector: "8086:a780"
         resourceName: "intel.com/sriov-gpudevice"
         externalResourceProvider: false
+      - pciVendorSelector: "$INTEL_IDV_GPU_VENDOR_ID:$INTEL_IDV_GPU_PRODUCT_ID"
+        resourceName: "intel.com/sriov-gpudevice"
+        externalResourceProvider: false


### PR DESCRIPTION
Useful for automation when installing the yaml file via an unattended system (RPM, etc.) 

Confirmed that this syntax, even if not substituted and loaded as-is will still work, the placeholder will just be ignored. Also confirmed that any duplicate entries created here are similarly ignored. 