### PR TITLE
fix : required feature gate not getting enabled in k3s air-gap

### DIFF
--- a/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
+++ b/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: kubevirt
 spec:
   configuration:
+    developerConfiguration:
+      featureGates:
+        - GPU
+        - HostDevices
+        - Sidecar
     permittedHostDevices:
       pciHostDevices:
       - pciVendorSelector: "8086:7dd5"


### PR DESCRIPTION
**Root Cause :** 
In a K3s air-gapped environment, once a KubeVirt feature gate is enabled via kubectl apply -f enable-feature-gate.yaml or by modifying the KubeVirt custom resource, it cannot be directly disabled or changed through those same methods.