### PR TITLE
Fix k3s airgap issue

### DIFF
--- a/.github/workflows/qemu-kubevirt.yaml
+++ b/.github/workflows/qemu-kubevirt.yaml
@@ -275,11 +275,7 @@ jobs:
           cd $EDV_HOME/workspace/kubevirt-artifacts
 
           cp $EDV_HOME/workspace/kubevirt/_out/manifests/release/kubevirt-operator.yaml .
-          cp $EDV_HOME/workspace/kubevirt/_out/manifests/release/kubevirt-cr.yaml .
-          cp $EDV_HOME/kubevirt-patch/kubevirt-cr-gfx-sriov.yaml .
-
-          # replace featureGates: [] with featureGates: - GPU - HostDevices - Sidecar
-          sed -i '/featureGates: \[\]/c\      featureGates:\n        - GPU\n        - HostDevices\n        - Sidecar' kubevirt-cr.yaml
+          cp $EDV_HOME/kubevirt-patch/kubevirt-cr.yaml .
 
           # Modify the generated operator yaml to specify images by tag, rather than sha256
           cat kubevirt-operator.yaml | sed '/name: VIRT_API_SHASUM/,/name: KUBEVIRT_VERSION/ { /name: KUBEVIRT_VERSION/!d }' > kubevirt-operator.new.yaml

--- a/kubevirt-patch/README.md
+++ b/kubevirt-patch/README.md
@@ -420,7 +420,7 @@ The original idea to build within the Centos container comes from this [link](ht
 10.  Enable Virt-Handler to discover Graphics VFs
      Update KubeVirt custom resource configuration to enable virt-handler to discover graphics VFs on the host. All discovered VFs will be published as *allocatable* resource
 
-     **Update Graphics Device ID in `kubevirt-cr-gfx-sriov.yaml` if not found**
+     **Update Graphics Device ID in `kubevirt-cr.yaml` if not found**
      - Read the Device ID of Intel Graphics Card from Host, Ex: for RPL
          ```sh
          $ cat /sys/devices/pci0000\:00/0000\:00\:02.0/device
@@ -436,7 +436,7 @@ The original idea to build within the Centos container comes from this [link](ht
 
      Apply the YAML changes
      ```sh
-     kubectl apply -f manifests/kubevirt-cr-gfx-sriov.yaml
+     kubectl apply -f manifests/kubevirt-cr.yaml
      ```
 
      **Check for presence of `intel.com/sriov-gpudevices` resource**

--- a/kubevirt-patch/kubevirt-cr.yaml
+++ b/kubevirt-patch/kubevirt-cr.yaml
@@ -1,9 +1,11 @@
+---
 apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:
   name: kubevirt
   namespace: kubevirt
 spec:
+  certificateRotateStrategy: {}
   configuration:
     developerConfiguration:
       featureGates:
@@ -174,3 +176,6 @@ spec:
       - pciVendorSelector: "${INTEL_IDV_GPU_VENDOR_ID}:${INTEL_IDV_GPU_PRODUCT_ID}"
         resourceName: "intel.com/sriov-gpudevice"
         externalResourceProvider: false
+  customizeComponents: {}
+  imagePullPolicy: IfNotPresent
+  workloadUpdateStrategy: {}

--- a/kubevirt-patch/kubevirt-offline-install.md
+++ b/kubevirt-patch/kubevirt-offline-install.md
@@ -58,7 +58,6 @@ Also the Device-Plugin has been shared as a [Device-Plugin TAR](https://github.c
     ```sh
     kubectl apply -f kubevirt-operator.yaml
     kubectl apply -f kubevirt-cr.yaml
-    kubectl apply -f kubevirt-cr-gfx-sriov.yaml
     kubectl apply -f intel-idv-device-plugin.yaml
     ```
 7.  Verify Deployment
@@ -86,7 +85,7 @@ Also the Device-Plugin has been shared as a [Device-Plugin TAR](https://github.c
 8.  Enable Virt-Handler to discover Graphics VFs
     Update KubeVirt custom resource configuration to enable virt-handler to discover graphics VFs on the host. All discovered VFs will be published as *allocatable* resource
 
-    **Update Graphics Device ID in `kubevirt-cr-gfx-sriov.yaml` if not found**
+    **Update Graphics Device ID in `kubevirt-cr.yaml` if not found**
       - Read the Device ID of Intel Graphics Card from Host, Ex: for RPL
         ```sh
         $ cat /sys/devices/pci0000\:00/0000\:00\:02.0/device
@@ -102,7 +101,7 @@ Also the Device-Plugin has been shared as a [Device-Plugin TAR](https://github.c
 
     Apply the YAML changes
     ```sh
-    kubectl apply -f manifests/kubevirt-cr-gfx-sriov.yaml
+    kubectl apply -f manifests/kubevirt-cr.yaml
     ```
 
     **Check for presence of `intel.com/sriov-gpudevices` resource**

--- a/kubevirt-patch/rpmbuild-install.md
+++ b/kubevirt-patch/rpmbuild-install.md
@@ -34,7 +34,6 @@ System should be installed with rpm build environment.
    ```sh
    sudo ls -la /var/lib/rancher/k3s/server/manifests/
    -rw-r--r--.  1 root root       3515 Jun 23 06:03 device-plugin.yaml
-   -rw-r--r--.  1 root root       1037 Jun 24 12:38 kubevirt-cr-gfx-sriov.yaml
    -rw-r--r--.  1 root root        288 Jun  5 11:31 kubevirt-cr.yaml
    -rw-r--r--.  1 root root     467574 Jun  3 14:54 kubevirt-operator.yaml
    ```
@@ -89,7 +88,6 @@ System should be installed with rpm build environment.
     ```sh
     kubectl apply -f kubevirt-operator.yaml
     kubectl apply -f kubevirt-cr.yaml
-    kubectl apply -f kubevirt-cr-gfx-sriov.yaml
     kubectl apply -f intel-idv-device-plugin.yaml
     ```
 7.  Verify Deployment
@@ -117,7 +115,7 @@ System should be installed with rpm build environment.
 8.  Enable Virt-Handler to discover Graphics VFs
     Update KubeVirt custom resource configuration to enable virt-handler to discover graphics VFs on the host. All discovered VFs will be published as *allocatable* resource
 
-    **Update Graphics Device ID in `kubevirt-cr-gfx-sriov.yaml` if not found**
+    **Update Graphics Device ID in `kubevirt-cr.yaml` if not found**
       - Read the Device ID of Intel Graphics Card from Host, Ex: for RPL
         ```sh
         $ cat /sys/devices/pci0000\:00/0000\:00\:02.0/device
@@ -133,7 +131,7 @@ System should be installed with rpm build environment.
 
     Apply the YAML changes
     ```sh
-    kubectl apply -f manifests/kubevirt-cr-gfx-sriov.yaml
+    kubectl apply -f manifests/kubevirt-cr.yaml
     ```
 
     **Check for presence of `intel.com/sriov-gpudevices` resource**


### PR DESCRIPTION
- creating kubevirt-cr.yaml which will be used instead of kubevirt-cr-gfx-sriov.yaml
- defaul file should not be downloaded from workflow
- workflow changes to copy the repo kubevirt-cr.yaml
- corresponding readme changes