### PR TITLE
Add xterm-in-docker and recipe for launching via Openbox

### DIFF
--- a/.github/workflows/openbox-xterm-shortcut.yaml
+++ b/.github/workflows/openbox-xterm-shortcut.yaml
@@ -1,0 +1,91 @@
+---
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Openbox xterm Shortcut: Build, Trivy Scan"
+run-name: "Workflow (by @${{ github.actor }} via ${{ github.event_name }})"
+
+# Only run at most 1 workflow concurrently per PR, unlimited for branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+jobs:
+  openbox-xterm-shortcut:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # All history, not just latest commit
+          ref: ${{ github.event.pull_request.head.sha }} # Check out the actual commit, not a fake merge commit
+
+      - name: Setup Tools & Common Variables
+        uses: ./.github/actions/setup-tools
+
+      - name: Build XTerm Docker Image
+        working-directory: openbox-xterm-shortcut
+        run: |
+          chmod +x ./build-xterm-docker.sh
+          # Note, this image is tagged with "latest" instead of "$EDV_VERSION"
+          ./build-xterm-docker.sh --name "localhost:5000/xterm-docker" --tag "latest"
+
+      - name: Build XTerm Docker release tarball
+        working-directory: openbox-xterm-shortcut
+        run: |
+          mkdir xterm-artifacts
+          cd xterm-artifacts
+
+          # Save the Docker image to a tarball
+          docker image save -o xterm-docker.tar "localhost:5000/xterm-docker:latest"
+
+          # Create a directory for the release and compress files
+          for file in *.tar; do
+            zstd --no-progress -T0 -16 -f --long=25 "$file" -o "${file}.zst"
+          done
+
+          mkdir xterm-docker-$EDV_VERSION
+          mv *.zst xterm-docker-$EDV_VERSION/
+
+          cp -a ../README.md xterm-docker-$EDV_VERSION/
+
+          # Create the final tarball
+          tar cvzf xterm-docker-$EDV_VERSION.tar.gz xterm-docker-$EDV_VERSION
+
+          ls -hal
+
+      - name: Upload xterm Docker release tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: xterm-docker-artifacts
+          path: |
+              openbox-xterm-shortcut/xterm-artifacts/xterm-docker-${{ env.EDV_VERSION }}.tar.gz
+
+      - name: Trivy Image Scan
+        continue-on-error: true
+        shell: bash
+        run: |
+              curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/html.tpl -o trivy-html.tpl
+              trivy image "localhost:5000/xterm-docker:latest" --ignore-unfixed --format template --template "@trivy-html.tpl" -o openbox-xterm-shortcut/trivy_image_scan_xterm.html
+              trivy image --quiet --format spdx-json --output openbox-xterm-shortcut/trivy_image_scan_xterm.spdx.json "localhost:5000/xterm-docker:latest"
+
+      - name: Upload Trivy Image Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: Trivy image scan report-xterm
+          path: |
+                openbox-xterm-shortcut/trivy_image_scan_xterm.html
+                openbox-xterm-shortcut/trivy_image_scan_xterm.spdx.json

--- a/openbox-xterm-shortcut/Dockerfile
+++ b/openbox-xterm-shortcut/Dockerfile
@@ -1,0 +1,75 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+FROM debian:stable
+
+# Proxy Configuration
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+
+# Add entrypoint script for host TTY connection
+COPY host-connect.sh /usr/local/bin/
+
+# Install xterm, better fonts, and tools needed for host TTY access in a single layer
+# and clean up in the same layer to reduce image size
+RUN chmod +x /usr/local/bin/host-connect.sh && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    xterm \
+    util-linux \
+    fonts-noto \
+    fonts-dejavu \
+    locales \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Set up locale with UTF-8 support
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    # Configure xterm defaults for better appearance and Unicode support
+    mkdir -p /etc/X11/app-defaults && \
+    cat > /etc/X11/app-defaults/XTerm <<EOF
+XTerm*faceName: DejaVu Sans Mono
+XTerm*faceSize: 12
+XTerm*renderFont: true
+XTerm*utf8: 1
+XTerm*locale: true
+XTerm*metaSendsEscape: true
+XTerm*saveLines: 10000
+XTerm*scrollBar: true
+XTerm*scrollbar.width: 8
+XTerm*foreground: rgb:d9/d9/d9
+XTerm*background: rgb:00/00/00
+XTerm*cursorColor: rgb:d9/d9/d9
+XTerm*cursorBlink: true
+EOF
+
+# Set environment variables for UTF-8 support
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# Set entrypoint to our connection script that directly connects to host login
+ENTRYPOINT ["/usr/local/bin/host-connect.sh"]
+
+# ==============================================
+# USAGE
+# ==============================================
+# To run this container with X11 and host TTY access, use:
+#   docker run -it --rm \
+#     -e DISPLAY=$DISPLAY \
+#     -v /tmp/.X11-unix:/tmp/.X11-unix \
+#     -v /dev/pts:/dev/pts:rw \
+#     --network=none \
+#     --pid=host \
+#     --privileged \
+#     xterm-docker:latest
+#
+# Required runtime parameters:
+# -e DISPLAY=$DISPLAY              : Passes your X11 display to the container
+# -v /tmp/.X11-unix:/tmp/.X11-unix : Mounts the X11 socket directory
+# -v /dev/pts:/dev/pts:rw          : Shares the host's TTY devices
+# --network=none                   : Disables all network access for the container
+# --pid=host                       : Shares the host's process namespace
+# --privileged                     : Needed for full host access

--- a/openbox-xterm-shortcut/README.md
+++ b/openbox-xterm-shortcut/README.md
@@ -1,0 +1,120 @@
+# Openbox XTerm Docker Shortcut
+
+This utility provides a containerized version of XTerm with enhanced Unicode support and improved fonts that can be easily launched from an Openbox window manager context menu.
+
+## Overview
+
+The Docker image contains a minimal Debian installation with XTerm, allowing you to run XTerm in an isolated container that connects to a login TTY on your host system. This gives you a proper login shell on the host while leveraging the containerized xterm application. The container follows a strict approach - it either successfully connects to the host login or fails completely without fallbacks. The image includes enhanced font rendering and Unicode support through DejaVu and Noto fonts.
+
+## Building the Image
+
+Use the provided build script to build the Docker image:
+
+```bash
+./build-xterm-docker.sh
+```
+
+### Build Options
+
+The build script supports the following options:
+
+| Option | Description |
+|--------|-------------|
+| `--name <image_name>` | Specify a custom image name (default: `localhost:5000/xterm-docker`) |
+| `--tag <image_tag>` | Specify a custom image tag (default: `latest`) |
+| `--help` | Display help information |
+
+
+Example:
+```bash
+./build-xterm-docker.sh --name localhost:5000/xterm-docker --tag latest
+```
+
+### Proxy Support
+
+If your environment requires proxy access to download packages, ensure HTTP_PROXY and HTTPS_PROXY (or their lowercase variants) are set prior to calling the `build-xterm-docker.sh` script.
+
+1. Use `HTTP_PROXY` and `HTTPS_PROXY` environment variables if they exist
+2. Fall back to `http_proxy` and `https_proxy` if the uppercase versions don't exist
+
+## Running the Container
+
+After building, you can run the container with:
+
+```bash
+docker run -it --rm \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v /dev/pts:/dev/pts:rw \
+  --network=none \
+  --pid=host \
+  --privileged \
+  localhost:5000/xterm-docker:latest
+```
+
+### Runtime Parameters
+
+| Parameter | Purpose |
+|-----------|---------|
+| `-e DISPLAY=$DISPLAY` | Passes your X11 display to the container |
+| `-v /tmp/.X11-unix:/tmp/.X11-unix` | Mounts the X11 socket directory |
+| `-v /dev/pts:/dev/pts:rw` | Shares the host's TTY devices |
+| `--network=none` | Disables all network access for the container |
+| `--pid=host` | Shares the host's process namespace |
+| `--privileged` | Grants necessary permissions for host TTY access |
+
+## Integrating with Openbox
+
+Add an entry to your Openbox `menu.xml` file (typically found at `~/.config/openbox/menu.xml`):
+
+```xml
+<item label="XTerm (Docker)">
+    <action name="Execute">
+        <command>docker run -it --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/pts:/dev/pts:rw --network=none --pid=host --privileged localhost:5000/xterm-docker:latest</command>
+    </action>
+</item>
+```
+
+Openbox can also be configured to launch the xterm docker image when pressing control+alt+t using the following configuration:
+
+```xml
+mkdir -p $HOME/.config/openbox
+cat <<EOF > $HOME/.config/openbox/rc.xml
+<openbox_config xmlns="http://openbox.org/3.6/rc">
+  <keyboard>
+    <keybind key="A-C-t">
+      <action name="Execute">
+        <command>docker run --rm -e DISPLAY=:0 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/pts:/dev/pts:rw --network=none --pid=host --privileged localhost:5000/xterm-docker:latest</command>
+      </action>
+    </keybind>
+  </keyboard>
+</openbox_config>
+EOF
+```
+
+## Troubleshooting
+
+### X11 Connection Issues
+
+If you encounter connection issues to the X11 server, try:
+
+```bash
+xhost +local:docker
+```
+
+### Container Exit Immediately
+
+If the container exits immediately, check that:
+1. Your X11 server allows connections from the container
+2. The DISPLAY environment variable is set correctly
+3. The container image is loaded into the docker image store
+3. The user launching the container has access to docker (especially for Openbox)
+
+### Host TTY Access Issues
+
+If you have trouble connecting to the host TTY:
+1. Make sure you're running Docker with the --privileged flag
+2. Verify that `/dev/pts` is properly mounted with read-write permissions
+3. Ensure the `--pid=host` flag is included to share the host's process namespace
+
+The container is designed to either work properly or fail completely - there is no fallback to a container shell. This strict behavior ensures you're always connecting to the host system and never accidentally operating in an isolated container environment.

--- a/openbox-xterm-shortcut/build-xterm-docker.sh
+++ b/openbox-xterm-shortcut/build-xterm-docker.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to build xterm Docker image with proxy support
+# This script passes HTTP_PROXY and HTTPS_PROXY environment variables
+# to the Docker build process if they exist
+
+# Default values
+DEFAULT_IMAGE_NAME="localhost:5000/xterm-docker"
+DEFAULT_IMAGE_TAG="latest"
+IMAGE_NAME="$DEFAULT_IMAGE_NAME"
+IMAGE_TAG="$DEFAULT_IMAGE_TAG"
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 [--name <image_name>] [--tag <image_tag>]"
+  echo "  --name <image_name>   Specify the image name (default: $DEFAULT_IMAGE_NAME)"
+  echo "  --tag <image_tag>     Specify the image tag (default: $DEFAULT_IMAGE_TAG)"
+  echo "  --help                Display this help message"
+  exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      IMAGE_NAME="$2"
+      shift 2
+      ;;
+    --tag)
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      ;;
+    *)
+      echo "Error: Unknown argument: $1"
+      usage
+      ;;
+  esac
+done
+
+echo "Building image: $IMAGE_NAME:$IMAGE_TAG"
+
+# Initialize build arguments string
+BUILD_ARGS=""
+
+# For HTTP_PROXY: Use $HTTP_PROXY if set, otherwise try $http_proxy
+if [ -n "$HTTP_PROXY" ]; then
+    BUILD_ARGS="$BUILD_ARGS --build-arg HTTP_PROXY=$HTTP_PROXY"
+elif [ -n "$http_proxy" ]; then
+    BUILD_ARGS="$BUILD_ARGS --build-arg HTTP_PROXY=$http_proxy"
+fi
+
+# For HTTPS_PROXY: Use $HTTPS_PROXY if set, otherwise try $https_proxy
+if [ -n "$HTTPS_PROXY" ]; then
+    BUILD_ARGS="$BUILD_ARGS --build-arg HTTPS_PROXY=$HTTPS_PROXY"
+elif [ -n "$https_proxy" ]; then
+    BUILD_ARGS="$BUILD_ARGS --build-arg HTTPS_PROXY=$https_proxy"
+fi
+
+echo "Building Docker image with the following command:"
+echo "docker build $BUILD_ARGS -t $IMAGE_NAME:$IMAGE_TAG ."
+
+if docker build $BUILD_ARGS -t "$IMAGE_NAME:$IMAGE_TAG" .; then
+    echo "Build successful! You can run the container with:"
+    echo "docker run -it --rm -e DISPLAY=\$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/pts:/dev/pts:rw --network=none --pid=host --privileged $IMAGE_NAME:$IMAGE_TAG"
+else
+    echo "Build failed!"
+    exit 1
+fi

--- a/openbox-xterm-shortcut/host-connect.sh
+++ b/openbox-xterm-shortcut/host-connect.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# host-connect.sh - Script to launch xterm with access to host TTY
+#
+# This script allows connecting to the host system's TTY from within
+# a Docker container running xterm
+
+# Check if host TTY devices are accessible
+if [ ! -d /dev/pts ] || [ ! -w /dev/pts ]; then
+    echo "ERROR: Cannot access host TTY devices. Make sure /dev/pts is mounted."
+    echo "Run the container with: -v /dev/pts:/dev/pts:rw"
+    exit 1
+fi
+
+# Check for required privileges by attempting a simple namespace operation
+if ! nsenter -t 1 -p true 2>/dev/null; then
+    echo "ERROR: Cannot access host PID namespace. Missing required privileges."
+    echo "Run the container with: --privileged --pid=host"
+    exit 1
+fi
+
+# We need to access the host PID namespace to connect to the host TTY
+if [ ! -e /proc/1/ns/pid ]; then
+    echo "ERROR: Cannot access host PID namespace."
+    echo "Make sure to run with: --pid=host"
+    exit 1
+fi
+
+# Launch xterm with a command to connect to the host's login process
+# Using all namespaces to ensure proper host access
+# No fallback logic - if the connection fails, the container exits
+exec xterm -T "Host TTY Connection" -e "nsenter -t 1 -m -u -i -n -p -- /bin/login"


### PR DESCRIPTION
- Package xterm & supporting fonts & libraries in a docker image
- When run, xterm connects to the host system's login system
- Openbox configuration provided to launch via hotkey from host


This currently needs review and possibly significant changes. In particular, this would require docker access for a user to be able to launch this via Openbox. 