### PR TITLE
Emt dv iso test

### DIFF
--- a/emt-dv-iso/build_idv_iso.sh
+++ b/emt-dv-iso/build_idv_iso.sh
@@ -19,7 +19,7 @@ DEFAULT_TAG=3.0.20250718
 # Default image config .json file. If this is NULL, default will be fetched from the repo.
 DEFAULT_IDV_JSON_PATH=""
 # This will be used only if above is NULL
-DEFAULT_IDV_JSON_GIT_FETCH="https://raw.githubusercontent.com/open-edge-platform/edge-desktop-virtualization/refs/heads/emt-dv-iso/emt-dv-iso/idv.json"
+DEFAULT_IDV_JSON_GIT_FETCH="https://raw.githubusercontent.com/open-edge-platform/edge-desktop-virtualization/refs/heads/emt-dv-iso-test/emt-dv-iso/idv.json"
 
 # ------------------- Global Variables ----------------------------
 

--- a/emt-dv-iso/build_idv_iso.sh
+++ b/emt-dv-iso/build_idv_iso.sh
@@ -19,7 +19,7 @@ DEFAULT_TAG=3.0.20250718
 # Default image config .json file. If this is NULL, default will be fetched from the repo.
 DEFAULT_IDV_JSON_PATH=""
 # This will be used only if above is NULL
-DEFAULT_IDV_JSON_GIT_FETCH="https://raw.githubusercontent.com/open-edge-platform/edge-desktop-virtualization/refs/heads/emt-dv-iso-test/emt-dv-iso/idv.json"
+DEFAULT_IDV_JSON_GIT_FETCH="https://raw.githubusercontent.com/open-edge-platform/edge-desktop-virtualization/refs/heads/emt-dv-iso/emt-dv-iso/idv.json"
 
 # ------------------- Global Variables ----------------------------
 

--- a/emt-dv-iso/idv.json
+++ b/emt-dv-iso/idv.json
@@ -15,8 +15,7 @@
                 "packagelists/intel-gpu-base.json",
                 "packagelists/drtm.json",
                 "packagelists/virt-guest-packages.json",
-                "packagelists/intel-wireless.json",
-                "packagelists/intel-idv-services.json"
+                "packagelists/intel-wireless.json"
             ],
             "Packages": [
                 "lsb-release",
@@ -27,7 +26,7 @@
                 "igt-gpu-tools"
 	        ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "udmabuf.list_limit=8192 i915.enable_guc=3 i915.max_vfs=7 intel_iommu=on iommu=pt i915.force_probe=*",
+                "ExtraCommandLine": "udmabuf.list_limit=8192 i915.enable_guc=3 i915.max_vfs=7 intel_iommu=on i915.force_probe=*",
                 "SELinux": "permissive"
             },
             "KernelOptions": {


### PR DESCRIPTION
1. Removing idv-services, which creates blank blinking '-' primary tty screen for non 'guest' users.
2. Removing iommu=pt. This is not required for gfx-SRIOV.

When iommu=pt is not needed:
For some Intel iGPUs using SR-IOV, the VFIO driver (which handles the passthrough) can manage the DMA translations without needing iommu=pt. In these cases, intel_iommu=on (or amd_iommu=on for AMD) might be sufficient for enabling the IOMMU functionality required for SR-IOV. 